### PR TITLE
Update to TensorFlow v0.12, slightly faster unpooling, clean-ups

### DIFF
--- a/DeconvNetPipeline.py
+++ b/DeconvNetPipeline.py
@@ -9,6 +9,8 @@ import argparse
 import time
 from datetime import datetime
 
+from utils import input_pipeline
+
 class DeconvNet:
     def __init__(self, images, segmentations, use_cpu=False, checkpoint_dir='./checkpoints/'):
         #self.maybe_download_and_extract()
@@ -271,54 +273,6 @@ if __name__ == '__main__':
     parser.add_argument('--num_epochs', help="number of epochs.", type=int, default=50)
     parser.add_argument('--lr',help="learning rate",type=float, default=1e-6)
     args = parser.parse_args()
-
-    def read_and_decode(filename_queue):
-        reader = tf.TFRecordReader()
-        _, serialized_example = reader.read(filename_queue)
-        features = tf.parse_single_example(
-            serialized_example,
-            # Defaults are not specified since both keys are required.
-            features={
-                'image_raw': tf.FixedLenFeature([], tf.string),
-                'mask_raw': tf.FixedLenFeature([], tf.string),
-            }
-        )
-
-        # must be read back as uint8 here
-        image = tf.decode_raw(features['image_raw'], tf.uint8)
-        segmentation = tf.decode_raw(features['mask_raw'], tf.uint8)
-
-        image.set_shape([224*224*3])
-        segmentation.set_shape([224*224*1])
-
-        image = tf.reshape(image,[224,224,3])
-        segmentation = tf.reshape(segmentation,[224,224])
-
-        rgb = tf.cast(image, tf.float32)
-        rgb = rgb * (1./255)
-        rgb = tf.cast(image, tf.float32)
-
-        mask = tf.cast(segmentation, tf.float32)
-        mask = (mask / 255.) * 20
-        mask = tf.cast(mask, tf.int64)
-        
-        return rgb, mask
-
-    def input_pipeline(filenames, batch_size, num_epochs):
-        filename_queue = tf.train.string_input_producer(
-            [filenames], num_epochs=num_epochs,shuffle=False)
-
-        image, label = read_and_decode(filename_queue)
-
-        min_after_dequeue = 1000
-        capacity = min_after_dequeue + 3 * batch_size
-        images_batch, labels_batch = tf.train.shuffle_batch(
-            [image, label], batch_size=batch_size,
-            enqueue_many=False, shapes=None,
-            allow_smaller_final_batch=True,
-            capacity=capacity,
-            min_after_dequeue=min_after_dequeue)
-        return images_batch, labels_batch
 
     trn_images_batch, trn_segmentations_batch = input_pipeline(
                                                     args.train_record,

--- a/DeconvNetPipeline.py
+++ b/DeconvNetPipeline.py
@@ -1,7 +1,7 @@
 import os
 import random
 import tensorflow as tf
-import wget
+#import wget
 import tarfile
 import numpy as np
 import argparse
@@ -17,7 +17,9 @@ class DeconvNet:
         self.y = segmentations
         self.build(use_cpu=use_cpu)
 
-        self.saver = tf.train.Saver(max_to_keep = 5, keep_checkpoint_every_n_hours =1)
+        #self.saver = tf.train.Saver(max_to_keep = 5, keep_checkpoint_every_n_hours =1)
+        self.saver = tf.train.Saver(tf.global_variables(), \
+            max_to_keep=5, keep_checkpoint_every_n_hours=1) # v0.12
         self.checkpoint_dir = checkpoint_dir
         #self.rate=lr
         #start=time.time()
@@ -334,19 +336,27 @@ if __name__ == '__main__':
 
     train_step=tf.train.AdamOptimizer(args.lr).minimize(loss_mean)
 
-    init = tf.initialize_all_variables()
-    init_locals = tf.initialize_local_variables()
+    summary_op = tf.summary.merge_all() # v0.12
+
+    #init = tf.initialize_all_variables()
+    #init_locals = tf.initialize_local_variables()
+
+    init_global = tf.global_variables_initializer() # v0.12
+    init_locals = tf.local_variables_initializer() # v0.12
 
     config = tf.ConfigProto(allow_soft_placement = True)
+
     with tf.Session(config=config) as sess:
 
-        sess.run([init, init_locals])
+        sess.run([init_global, init_locals])
         
         coord = tf.train.Coordinator()
         threads = tf.train.start_queue_runners(coord=coord)
 
-        summary_writer = tf.train.SummaryWriter(args.train_dir, sess.graph)
-        training_summary = tf.scalar_summary("loss", loss_mean)
+        #summary_writer = tf.train.SummaryWriter(args.train_dir, sess.graph)
+        summary_writer = tf.summary.FileWriter(args.train_dir, sess.graph) # v0.12
+        #training_summary = tf.scalar_summary("loss", loss_mean)
+        training_summary = tf.summary.scalar("loss", loss_mean) # v0.12
         
         try:
             step=0

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,49 @@
+import tensorflow as tf
+
+def read_and_decode(filename_queue):
+    reader = tf.TFRecordReader()
+    _, serialized_example = reader.read(filename_queue)
+    features = tf.parse_single_example(
+        serialized_example,
+        # Defaults are not specified since both keys are required.
+        features={
+            'image_raw': tf.FixedLenFeature([], tf.string),
+            'mask_raw': tf.FixedLenFeature([], tf.string),
+        }
+    )
+
+    # must be read back as uint8 here
+    image = tf.decode_raw(features['image_raw'], tf.uint8)
+    segmentation = tf.decode_raw(features['mask_raw'], tf.uint8)
+
+    image.set_shape([224*224*3])
+    segmentation.set_shape([224*224*1])
+
+    image = tf.reshape(image,[224,224,3])
+    segmentation = tf.reshape(segmentation,[224,224])
+
+    rgb = tf.cast(image, tf.float32)
+    rgb = rgb * (1./255)
+    rgb = tf.cast(image, tf.float32)
+
+    mask = tf.cast(segmentation, tf.float32)
+    mask = (mask / 255.) * 20
+    mask = tf.cast(mask, tf.int64)
+    
+    return rgb, mask
+
+def input_pipeline(filenames, batch_size, num_epochs):
+    filename_queue = tf.train.string_input_producer(
+        [filenames], num_epochs=num_epochs,shuffle=False)
+
+    image, label = read_and_decode(filename_queue)
+
+    min_after_dequeue = 1000
+    capacity = min_after_dequeue + 3 * batch_size
+    images_batch, labels_batch = tf.train.shuffle_batch(
+        [image, label], batch_size=batch_size,
+        enqueue_many=False, shapes=None,
+        allow_smaller_final_batch=True,
+        capacity=capacity,
+        min_after_dequeue=min_after_dequeue)
+    return images_batch, labels_batch

--- a/write-tfrecords/img_to_tfrecords.py
+++ b/write-tfrecords/img_to_tfrecords.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     parser=argparse.ArgumentParser()
     parser.add_argument('--imgpath',help="path to images",default="data/VOC_OBJECT/dataset_multlabel/images/")
     parser.add_argument('--segpath',help="path to segmentations",default="data/VOC_OBJECT/dataset_multlabel/segmentations/")
+    parser.add_argument('--outpath',help="path to write tfrecord",default="tfrecords/")
     parser.add_argument('--rec',help="tfrecord file name to write",default="pascalvoc2012")
     parser.add_argument('--crop',help="should we crop/pad images to fixed size?",default="y")
     args=parser.parse_args()
@@ -57,13 +58,14 @@ if __name__ == '__main__':
         myImg = tf.image.resize_image_with_crop_or_pad(myImg, 224, 224)
         mySeg = tf.image.resize_image_with_crop_or_pad(mySeg, 224, 224)
 
-    init=tf.initialize_all_variables()
+    #init=tf.initialize_all_variables()
+    init_global = tf.global_variables_initializer() # v0.12
 
     with tf.Session() as sess:
 
-        filename=os.path.join('tfrecords/'+args.rec+'.tfrecords')
+        filename=os.path.join(args.outpath+args.rec+'.tfrecords')
         print('Writing', filename)
-        sess.run(init)
+        sess.run(init_global)
         coord=tf.train.Coordinator()
         threads=tf.train.start_queue_runners(coord=coord)
         writer=tf.python_io.TFRecordWriter(filename)


### PR DESCRIPTION
- Minor updates for v0.11 to v0.12
- Use tf.scatter in batch unpooling
- Move auxiliary methods, e.g setup of pipeline out of main.

Trains at 3.5 img/sec on Titan X with batch size 10